### PR TITLE
updated eiffel remrem parent, shared semantics version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.6
+- Updated versions of parent from 0.0.5 to 0.0.6 and shared from 0.3.9 to 0.4.0
+- Uplifted semantics version from 0.5.0 to 0.5.1
+
 ## 0.10.5
 - Updated parent, shared and semantics version
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.github.Ericsson</groupId>
         <artifactId>eiffel-remrem-parent</artifactId>
-        <version>0.0.5</version>
+        <version>0.0.6</version>
     </parent>
     <properties>
-        <eiffel-remrem-generate.version>0.10.5</eiffel-remrem-generate.version>
-        <eiffel-remrem-shared.version>0.3.9</eiffel-remrem-shared.version>
-        <eiffel-remrem-semantics.version>0.5.0</eiffel-remrem-semantics.version>
+        <eiffel-remrem-generate.version>0.10.6</eiffel-remrem-generate.version>
+        <eiffel-remrem-shared.version>0.4.0</eiffel-remrem-shared.version>
+        <eiffel-remrem-semantics.version>0.5.1</eiffel-remrem-semantics.version>
     </properties>
     <artifactId>eiffel-remrem-generate</artifactId>
     <version>${eiffel-remrem-generate.version}</version>


### PR DESCRIPTION
### Description of the Change
updated eiffel remrem parent  version from 0.0.5 to 0.0.6 
eiffel remremshared  version from 0.3.9 to 0.4.0
eiffel remrem semantics version from 0.5.0 to 0.5.1

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
