### PR TITLE
Adapted application to execute without external tomcat installation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,13 @@
     </repositories>
     <build>
         <plugins>
+             <plugin>   
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.6.1</version>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -86,6 +86,23 @@
     </dependencies>
     <build>
         <plugins>
+			<plugin>
+
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+		        <configuration>    
+                    <mainClass>com.ericsson.eiffel.remrem.generate.App</mainClass>
+                    <fork>true</fork>
+                    <skip>false</skip>
+                </configuration>
+                <executions>
+                  <execution>
+                    <goals>
+                      <goal>repackage</goal>
+                    </goals>
+                  </execution>
+                </executions>
+			</plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
@@ -94,6 +111,9 @@
                         <manifestEntries>
                             <serviceVersion>${project.version}</serviceVersion>
                             <remremVersionKey>serviceVersion</remremVersionKey>
+                            <addClasspath>true</addClasspath>
+							<classpathPrefix>lib/</classpathPrefix>
+							<mainClass>com.ericsson.eiffel.remrem.generate.App</mainClass>
                         </manifestEntries>
                     </archive>
                     <failOnMissingWebXml>false</failOnMissingWebXml>


### PR DESCRIPTION
### Applicable Issues
Today RemRem require external Tomcat instance.
Configuration is not as simple as it could be and it is not possible to test application locally.

### Description of the Change
Adapt application so it is possible to execute it without external Tomcat.
Add possbility to configuret Spring from Java arguments and properties and take a application properties as input configuration.
This simplifies a lot the configuration of RemRem in a container environment.

STATUS:
Works:
    - Executing Spring from war file works.
    - 'mvn spring-boot:run' works
    - RemRem-genereat war file in TomCat installation with Java Spring properties works.

To Be Tested:
    - RemRem-generate war file in TomCat installation with catalina.home properties.
    Provide the catalina.home property before start catalina.sh, e.g. 'catalina.home=/usr/local/tomcat' and property file should be placed at this path: /usr/local/tomcat/conf/config.properties

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
