### PR TITLE
Upgraded eiffel-remrem-semantics version from 2.0.3 to 2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+## 2.0.3
+- Upgraded eiffel-remrem-semantics version from 2.0.3 to 2.0.4
+
 ## 2.0.2
 - Upgraded eiffel-remrem-semantics version from 2.0.2 to 2.0.3.
+
 ## 2.0.1
 - Upgraded eiffel-remrem-semantics version from 2.0.1 to 2.0.2.
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,9 @@
     </parent>
 
     <properties>
-        <eiffel-remrem-generate.version>2.0.2</eiffel-remrem-generate.version>
+        <eiffel-remrem-generate.version>2.0.3</eiffel-remrem-generate.version>
         <eiffel-remrem-shared.version>2.0.0</eiffel-remrem-shared.version>
-        <eiffel-remrem-semantics.version>2.0.3</eiffel-remrem-semantics.version>
+        <eiffel-remrem-semantics.version>2.0.4</eiffel-remrem-semantics.version>
     </properties>
     <artifactId>eiffel-remrem-generate</artifactId>
     <version>${eiffel-remrem-generate.version}</version>


### PR DESCRIPTION

### Description of the Change
Upgraded eiffel-remrem-semantics version from 2.0.3 to 2.0.4


