### PR TITLE
REMReM generate service is being stopped when ER not configured.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.8
+- REMReM generate service is being started when ER not configured.
+
+## 2.0.7
+- Update pom.xml
+
 ## 2.0.6
 - Added ER Lookup configurations for a link and code to handle the lookup towards ER when generating events.
 - Uplifted eiffel-remrem-generate version from 2.0.5 to 2.0.6

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <eiffel-remrem-generate.version>2.0.7</eiffel-remrem-generate.version>
+        <eiffel-remrem-generate.version>2.0.8</eiffel-remrem-generate.version>
         <eiffel-remrem-shared.version>2.0.2</eiffel-remrem-shared.version>
         <eiffel-remrem-semantics.version>2.0.6</eiffel-remrem-semantics.version>
     </properties>

--- a/service/src/main/java/com/ericsson/eiffel/remrem/generate/config/ErLookUpConfig.java
+++ b/service/src/main/java/com/ericsson/eiffel/remrem/generate/config/ErLookUpConfig.java
@@ -37,9 +37,9 @@ public class ErLookUpConfig {
 
     Logger log = (Logger) LoggerFactory.getLogger(ErLookUpConfig.class);
 
-    @Value("${event-repository.url}")
+    @Value("${event-repository.url:null}")
     private String erURL;
-    @Value("${event-repository.enabled}")
+    @Value("${event-repository.enabled:false}")
     private String eventRepositoryEnabled;
 
     private boolean eventRepositoryCheck;


### PR DESCRIPTION
Remrem-generate is being stopped when event repository configurations are not configured in application.properties.