### PR TITLE
Log exceptions in catch-all exception traps (fixes #140)

### DIFF
--- a/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/RemremGenerateController.java
+++ b/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/RemremGenerateController.java
@@ -122,6 +122,7 @@ public class RemremGenerateController {
                 return new ResponseEntity<>(parser.parse(e1.getMessage()), HttpStatus.EXPECTATION_FAILED);
             }
         } catch (Exception e) {
+            log.error("Unexpected exception caught", e);
             return new ResponseEntity<>(parser.parse(RemremGenerateServiceConstants.INTERNAL_SERVER_ERROR),
                     HttpStatus.INTERNAL_SERVER_ERROR);
         }
@@ -214,6 +215,7 @@ public class RemremGenerateController {
                         HttpStatus.SERVICE_UNAVAILABLE, requestEntity);
             }
         } catch (Exception e) {
+            log.error("Unexpected exception caught", e);
             return presentResponse(parser.parse(RemremGenerateServiceConstants.INTERNAL_SERVER_ERROR),
                     HttpStatus.INTERNAL_SERVER_ERROR, requestEntity);
         }
@@ -249,6 +251,7 @@ public class RemremGenerateController {
                         HttpStatus.SERVICE_UNAVAILABLE, requestEntity);
             }
         } catch (Exception e) {
+            log.error("Unexpected exception caught", e);
             return presentResponse(parser.parse(RemremGenerateServiceConstants.INTERNAL_SERVER_ERROR),
                     HttpStatus.INTERNAL_SERVER_ERROR, requestEntity);
         }


### PR DESCRIPTION
### Applicable Issues
#140 

### Description of the Change
Add trivial logging statements to `catch (Exception e) { ... }` exception handlers so that unanticipated exceptions can be debugged after the fact.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>