### PR TITLE
Fix typo in REMReM Publish link URL

### DIFF
--- a/serviceUsage.html
+++ b/serviceUsage.html
@@ -39,7 +39,7 @@
         </h1>
 
         <p>REMReM Generate Service allows generating of Eiffel messages that will be send by <a
-                href="https://eiffel-community.github.io/eiffel-remrem-semantics/">Eiffel REMReM Publish</a> to RabbitMQ.</p>
+                href="https://eiffel-community.github.io/eiffel-remrem-publish/">Eiffel REMReM Publish</a> to RabbitMQ.</p>
 
         <p>Information about the REMReM Generate Service all endpoints can be got and easily accessed using next links:</p>
         <pre>http://&lt;host&gt;:&lt;port&gt;/&lt;application name&gt;/</pre>


### PR DESCRIPTION
### Applicable Issues
N/A; trivial typo correction.

### Description of the Change
The link target for the text "Eiffel REMReM Publish" was https://eiffel-community.github.io/eiffel-remrem-semantics/ instead of https://eiffel-community.github.io/eiffel-remrem-publish/.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
