### PR TITLE
Fix for ER Lookup functionality do not work due to hardcoded contex…

### DIFF
--- a/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/ERLookupController.java
+++ b/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/ERLookupController.java
@@ -32,7 +32,7 @@ public class ERLookupController {
             final JsonObject lookup = link.get("%lookup%").getAsJsonObject();
             final String eventType = lookup.get("eventType").getAsString();
             final JsonArray lookUpParams = lookup.get("properties").getAsJsonArray();
-            final StringBuilder queryBuilder = new StringBuilder("/eventrepository/events?meta.type=" + eventType);
+            final StringBuilder queryBuilder = new StringBuilder("/events?meta.type=" + eventType);
             StreamSupport.stream(lookUpParams.spliterator(), false)
             .forEach(jsonArray -> {
                 for (Entry<String, JsonElement> entry : jsonArray.getAsJsonObject().entrySet()) {

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -25,4 +25,4 @@ activedirectory.userSearchFilter:
 #Event Repository configurations
 
 event-repository.enabled:false
-event-repository.url :http://localhost:<port>/optional to specify context-path
+event-repository.url :http://<host>:<port>/<context-path-if-available>

--- a/service/src/test/java/com/ericsson/eiffel/remrem/generate/service/EiffelRemERLookupControllerUnitTest.java
+++ b/service/src/test/java/com/ericsson/eiffel/remrem/generate/service/EiffelRemERLookupControllerUnitTest.java
@@ -141,22 +141,22 @@ public class EiffelRemERLookupControllerUnitTest {
 
         ResponseEntity erresponse = new ResponseEntity(response, HttpStatus.OK);
         when(restTemplate.getForEntity(
-                Mockito.contains("/eventrepository/events?meta.type=EiffelArtifactCreatedEvent&data.identity=swdi.up/CXP102051_22@R21EK"),
+                Mockito.contains("/events?meta.type=EiffelArtifactCreatedEvent&data.identity=swdi.up/CXP102051_22@R21EK"),
                 Mockito.eq(String.class))).thenReturn(erresponse);
 
         ResponseEntity compositionErResponse = new ResponseEntity(compositionResponse, HttpStatus.OK);
         Mockito.when(restTemplate.getForEntity(
-                Mockito.contains("/eventrepository/events?meta.type=EiffelSourceChangeCreatedEvent&data.gitIdentifier.commitId=fd090b60a4aedc5161da9c035a49b14a319829b4&data.gitIdentifier.repoUri=https://github.com/johndoe/myPrivateRepo.git"),
+                Mockito.contains("/events?meta.type=EiffelSourceChangeCreatedEvent&data.gitIdentifier.commitId=fd090b60a4aedc5161da9c035a49b14a319829b4&data.gitIdentifier.repoUri=https://github.com/johndoe/myPrivateRepo.git"),
                 Mockito.eq(String.class))).thenReturn(compositionErResponse);
 
         ResponseEntity compositionEr1Response = new ResponseEntity(compositionSCSubmittedResponse, HttpStatus.OK);
         Mockito.when(restTemplate.getForEntity(
-                Mockito.contains("/eventrepository/events?meta.type=EiffelSourceChangeSubmittedEvent&data.gitIdentifier.commitId=fd090b60aedc535a49b14a&data.gitIdentifier.repoUri=https://github.com/johndoe/myPrivateRepo.git"),
+                Mockito.contains("/events?meta.type=EiffelSourceChangeSubmittedEvent&data.gitIdentifier.commitId=fd090b60aedc535a49b14a&data.gitIdentifier.repoUri=https://github.com/johndoe/myPrivateRepo.git"),
                 Mockito.eq(String.class))).thenReturn(compositionEr1Response);
 
         ResponseEntity SCSubmittedErResponse = new ResponseEntity(SCSubmittedResponse, HttpStatus.OK);
         Mockito.when(restTemplate.getForEntity(
-                Mockito.contains("/eventrepository/events?meta.type=EiffelSourceChangeCreatedEvent&data.gitIdentifier.commitId=fd090b60a4aedc5161da9c035a49b14a319829b4&data.gitIdentifier.repoUri=https://github.com/myPrivateRepo.git"),
+                Mockito.contains("/events?meta.type=EiffelSourceChangeCreatedEvent&data.gitIdentifier.commitId=fd090b60a4aedc5161da9c035a49b14a319829b4&data.gitIdentifier.repoUri=https://github.com/myPrivateRepo.git"),
                 Mockito.eq(String.class))).thenReturn(SCSubmittedErResponse);
     }
 


### PR DESCRIPTION
…t path

<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->

### Applicable Issues
https://github.com/eiffel-community/eiffel-remrem-generate/issues/146

### Description of the Change
Removed code where the context path was hardcoded, and modified the test cases to verify

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
Failing functionality towards ER lookups

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
