### PR TITLE
Fix for ER Lookup functionality do not work due to hardcoded context

### DIFF
--- a/serviceUsage.html
+++ b/serviceUsage.html
@@ -166,11 +166,11 @@ activedirectory.userSearchFilter: &lt;LDAP userSearchFilter pattern&gt;</pre>
             <p>If <em>event-repository.enabled</em> is false then REMReM Generate will not Lookup ER data. Refer below snippet for instance,</p>
             <pre>
             event-repository.enabled : false
-            event-repository.url     : &lt;ER URL for lookup&gt;</pre>
+            event-repository.url     : http(s)://&lt;host&gt;:&lt;port&gt;/&lt;context-path&gt;</pre>
         <p>If <em>event-repository.enabled</em> is true then Event Repository URL should be mandatory. </p>
             <pre>
             event-repository.enabled : true
-            event-repository.url     : &lt;ER URL for lookup&gt;</pre>
+            event-repository.url     : http(s)://&lt;host&gt;:&lt;port&gt;/&lt;context-path&gt;</pre>
         <p><strong>NOTE: </strong>If Lookup configurations are enabled and EventRepository URL is not provided then the remrem service gets terminated.</p>
         <pre>
             event-repository.enabled : true


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->

### Applicable Issues
https://github.com/eiffel-community/eiffel-remrem-generate/issues/146

### Description of the Change
Updated the documentation to reflect the context path parameter to be visible in the configuration.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
Clear understanding about how to configure the ER Url.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
