### PR TITLE
Update Dockerfile to use fabric8/java-centos-openjdk8-jre image

### DIFF
--- a/service/src/main/docker/Dockerfile
+++ b/service/src/main/docker/Dockerfile
@@ -1,9 +1,15 @@
-FROM tomcat:8.0-jre8
+FROM fabric8/java-centos-openjdk8-jre:1.6.4
 MAINTAINER Eiffel-Community 
-ARG URL
-RUN echo Building RemRem-Generate image based on artifact url: ${URL}
-RUN ["rm", "-fr", "/usr/local/tomcat/webapps/ROOT"]
-ADD ${URL} /usr/local/tomcat/webapps/ROOT.war
-
 EXPOSE 8080
-CMD ["catalina.sh", "run"]
+ARG URL
+
+# Explicitly select the file to pass to "java -jar" so that additional
+# jar dependencies can be added to ${JAVA_APP_DIR} without creating
+# ambiguity.
+ENV JAVA_APP_JAR ${JAVA_APP_DIR}/generate.war
+
+# Disable Jolokia and jmx_exporter.
+ENV AB_OFF true
+
+RUN echo Building RemRem-Generate image based on artifact url: ${URL}
+ADD --chown=jboss ${URL} ${JAVA_APP_JAR}

--- a/wiki/markdown/docker.md
+++ b/wiki/markdown/docker.md
@@ -64,9 +64,6 @@ It is possible to set all Spring available properties via docker envrionment "-e
 ## Docker flags
 
 
-<B>"--expose 8080"</B> - this Docker flag tells that containers internal port shall be exposed to outside of the Docker Host. This flag do not set which port that should be allocated outside Docker Host on the actual server/machine.
-
-
 <B>"-p 8081:8080"</B> - this Docker flag is mapping the containers external port 8081 to the internal exposed port 8080. Port 8081 will be allocated outside Docker host and user will be able to access the containers service via port 8081.
 
 
@@ -74,10 +71,18 @@ When RemRem-Generate container is running on your local Docker host, RemRem-Gene
 
 
 Another option to configure RemRem-Generate is to provide the application properties file into the container, which can be made in two ways:
-1. Put application.properties file in Tomcat Catalina config folder in container and run RemRem-Generate:
+1. Put application.properties file in the container's /deployments folder and run RemRem-Generate:
 
-`docker run -p 8081:8080 --expose 8080 --volume /path/to/application.properties:/usr/local/tomcat/config/application.properties remrem-generate`
+`docker run -p 8081:8080 --volume /path/to/application.properties:/deployments/application.properties remrem-generate`
 
 2. Put application.properties file in a different folder in container and tell RemRem-Generate where the application.properties is located in the container:
 
-`docker run -p 8081:8080 --expose 8080 --volume /path/to/application.properties:/tmp/application.properties -e spring.config.location=/tmp/application.properties remrem-generate`
+`docker run -p 8081:8080 --volume /path/to/application.properties:/tmp/application.properties -e spring.config.location=/tmp/application.properties remrem-generate`
+
+If you need to pass additional flags to the JVM (like setting a custom
+heap size) you can include those flags in the JAVA_OPTIONS environment
+variable. See the documentation of the
+[fabric8/java-centos-openjdk8-jre][docker-image-docs] Docker image for
+full details.
+
+[docker-image-docs]: https://hub.docker.com/r/fabric8/java-centos-openjdk8-jre


### PR DESCRIPTION
### Applicable Issues
#142 

### Description of the Change
When running REMReM Generate in a Docker container there's little point in using a Tomcat image (tomcat:8.0-jre8) and running the war file as the sole application in its Tomcat instance. There are also a few concrete problems in such a setup:

- Because the process inside the container with pid 1 won't respond      to SIGTERM signals, container shutdowns will (by default) take      ten seconds and the processes will be stopped with SIGKILL,      leaving no opportunity to clean anything up.
- Tomcat and the application each have their own logging      configurations, so introducing a common log format or rotation      means extra work.

By switching to fabric8/java-centos-openjdk8-jre we run the war file as a standalone application with the Tomcat that's built into Spring Boot.

This commit introduces a backwards incompatible change, namely that the directory where the application looks for application.properties changes.

While updating the Docker documentation we also drop references to the `--expose` flag since it's superfluous given the "EXPOSE 8080" instruction in the dockerfile.

### Benefits
The problems described above are addressed.

### Possible Drawbacks
Sites that prefer to run Java wars via Tomcat won't be able to use this image anymore, but they can just run a plain Tomcat image and place the war file in the right directory.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
