### PR TITLE
REMReM lookups controlled per lookup link instead of globally per call.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.16
+- REMReM lookups controlled 'failIfNoneFound' and 'failIfMultipleFound' lookups per lookup
+  object within an event instead of globally per call.
+
 ## 2.0.15
 - Fixed the broken link which points to generate documentation in swagger.
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <eiffel-remrem-generate.version>2.0.15</eiffel-remrem-generate.version>
+        <eiffel-remrem-generate.version>2.0.16</eiffel-remrem-generate.version>
         <eiffel-remrem-shared.version>2.0.4</eiffel-remrem-shared.version>
         <eiffel-remrem-semantics.version>2.0.13</eiffel-remrem-semantics.version>
     </properties>

--- a/service/src/main/java/com/ericsson/eiffel/remrem/generate/constants/RemremGenerateServiceConstants.java
+++ b/service/src/main/java/com/ericsson/eiffel/remrem/generate/constants/RemremGenerateServiceConstants.java
@@ -35,6 +35,9 @@ public final class RemremGenerateServiceConstants {
         public static final String UNAVAILABLE_FOR_FAILIFNONEFOUND = "{\"status_code\": 406, \"result\": \"FAIL\", "
                 + "\"message\":\"No event id found with ERLookup properties\"}";
 
+        public static final String UNAVAILABLE_LOOKUP_OPTIONS = "{\"status_code\": 422, \"result\": \"FAIL\", "
+                + "\"message\":\"Link specific options could not be fulfilled\"}";
+
         public static final String LOOKUP_LIMIT = "The maximum number of events returned from a lookup. If more events "
         		+ "are found they will be disregarded. The order of the events is undefined, which means that what events are "
         		+ "disregarded is also undefined.";

--- a/service/src/main/java/com/ericsson/eiffel/remrem/generate/constants/RemremGenerateServiceConstants.java
+++ b/service/src/main/java/com/ericsson/eiffel/remrem/generate/constants/RemremGenerateServiceConstants.java
@@ -36,7 +36,7 @@ public final class RemremGenerateServiceConstants {
                 + "\"message\":\"No event id found with ERLookup properties\"}";
 
         public static final String UNAVAILABLE_LOOKUP_OPTIONS = "{\"status_code\": 422, \"result\": \"FAIL\", "
-                + "\"message\":\"Link specific options could not be fulfilled\"}";
+                + "\"message\":\"Link specific options could not fetch information from ER\"}";
 
         public static final String LOOKUP_LIMIT = "The maximum number of events returned from a lookup. If more events "
         		+ "are found they will be disregarded. The order of the events is undefined, which means that what events are "

--- a/service/src/main/java/com/ericsson/eiffel/remrem/generate/constants/RemremGenerateServiceConstants.java
+++ b/service/src/main/java/com/ericsson/eiffel/remrem/generate/constants/RemremGenerateServiceConstants.java
@@ -35,8 +35,8 @@ public final class RemremGenerateServiceConstants {
         public static final String UNAVAILABLE_FOR_FAILIFNONEFOUND = "{\"status_code\": 406, \"result\": \"FAIL\", "
                 + "\"message\":\"No event id found with ERLookup properties\"}";
 
-        public static final String UNAVAILABLE_LOOKUP_OPTIONS = "{\"status_code\": 422, \"result\": \"FAIL\", "
-                + "\"message\":\"Link specific options could not fetch information from ER\"}";
+        public static final String LOOKUP_OPTIONS_NOT_FULFILLED = "{\"status_code\": 422, \"result\": \"FAIL\", "
+                + "\"message\":\"Link specific lookup options could not be fulfilled\"}";
 
         public static final String LOOKUP_LIMIT = "The maximum number of events returned from a lookup. If more events "
         		+ "are found they will be disregarded. The order of the events is undefined, which means that what events are "

--- a/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/RemremGenerateController.java
+++ b/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/RemremGenerateController.java
@@ -168,8 +168,8 @@ public class RemremGenerateController {
                     }
                     String responseBody = response.getBody();
                     ids = ERLookupController.getIdsfromResponseBody(responseBody);
-                    boolean failIfNoneFoundValue=failIfNoneFound;
-                    boolean failIfMultipleFoundValue=failIfMultipleFound;
+                    boolean failIfNoneFoundValue = failIfNoneFound;
+                    boolean failIfMultipleFoundValue = failIfMultipleFound;
 
                     // Checking ER lookup has options field present or not
                     if (lookupLinks.get(i).toString().contains("options")) {

--- a/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/RemremGenerateController.java
+++ b/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/RemremGenerateController.java
@@ -168,6 +168,8 @@ public class RemremGenerateController {
                     }
                     String responseBody = response.getBody();
                     ids = ERLookupController.getIdsfromResponseBody(responseBody);
+                    boolean failIfNoneFoundValue=failIfNoneFound;
+                    boolean failIfMultipleFoundValue=failIfMultipleFound;
 
                     // Checking ER lookup has options field present or not
                     if (lookupLinks.get(i).toString().contains("options")) {
@@ -178,10 +180,10 @@ public class RemremGenerateController {
                             final String optionValue = options.getValue().getAsString();
                             if (optionKey.equals("failIfNoneFound") && (optionValue.equalsIgnoreCase("true")
                                     || optionValue.equalsIgnoreCase("false"))) {
-                                failIfNoneFound = Boolean.parseBoolean(optionValue);
+                                failIfNoneFoundValue = Boolean.parseBoolean(optionValue);
                             } else if (optionKey.equals("failIfMultipleFound") && (optionValue.equalsIgnoreCase("true")
                                     || optionValue.equalsIgnoreCase("false"))) {
-                                failIfMultipleFound = Boolean.parseBoolean(optionValue);
+                                failIfMultipleFoundValue = Boolean.parseBoolean(optionValue);
                             } else {
                                 throw new REMGenerateException(
                                         RemremGenerateServiceConstants.UNAVAILABLE_LOOKUP_OPTIONS);
@@ -190,10 +192,10 @@ public class RemremGenerateController {
                     }
 
                     // Checking ER lookup result
-                    if (failIfMultipleFound && ids != null && ids.length > 1) {
+                    if (failIfMultipleFoundValue && ids != null && ids.length > 1) {
                         throw new REMGenerateException(
                                 RemremGenerateServiceConstants.UNAVAILABLE_FOR_FAILIFMULTIPLEFOUND);
-                    } else if (failIfNoneFound && ids.length == 0) {
+                    } else if (failIfNoneFoundValue && ids.length == 0) {
                         throw new REMGenerateException(RemremGenerateServiceConstants.UNAVAILABLE_FOR_FAILIFNONEFOUND);
                     }
 

--- a/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/RemremGenerateController.java
+++ b/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/RemremGenerateController.java
@@ -186,7 +186,7 @@ public class RemremGenerateController {
                                 failIfMultipleFoundValue = Boolean.parseBoolean(optionValue);
                             } else {
                                 throw new REMGenerateException(
-                                        RemremGenerateServiceConstants.UNAVAILABLE_LOOKUP_OPTIONS);
+                                        RemremGenerateServiceConstants.LOOKUP_OPTIONS_NOT_FULFILLED);
                             }
                         }
                     }

--- a/service/src/test/java/com/ericsson/eiffel/remrem/generate/service/EiffelRemERLookupControllerUnitTest.java
+++ b/service/src/test/java/com/ericsson/eiffel/remrem/generate/service/EiffelRemERLookupControllerUnitTest.java
@@ -124,12 +124,27 @@ public class EiffelRemERLookupControllerUnitTest {
         String erLookupWithOptionsOutput = FileUtils
                 .readFileToString(new File(TEST_RESOURCES_PATH+"ErlookupWithOptionsOutput.json"), ENCODING);
 
+        String erlookupOptionsWithEmptyResponseOutput = FileUtils
+                .readFileToString(new File(TEST_RESOURCES_PATH+"ErlookupOptionsWithEmptyResponseOutput.json"), ENCODING);
+
         String erLookupWithOptionsResponse = FileUtils
                 .readFileToString(new File(TEST_RESOURCES_PATH+"ErlookupWithOptionsResponse.json"), ENCODING);
 
+        String erLookupWithOptionsResponse2 = FileUtils
+                .readFileToString(new File(TEST_RESOURCES_PATH+"ErlookupWithOptionsResponse2.json"), ENCODING);
+        
+        String emptyResponse = FileUtils
+                .readFileToString(new File(TEST_RESOURCES_PATH+"EmptyResponse.json"), ENCODING);
+
         String ErlookupFailedWithOptionsOutput = FileUtils
                 .readFileToString(new File(TEST_RESOURCES_PATH+"ErlookupFailedWithOptionsOutput.json"), ENCODING);
+        
+        String erlookupOptionsWithNoneFoundOutput = FileUtils
+                .readFileToString(new File(TEST_RESOURCES_PATH+"erlookupOptionsWithNoneFoundOutput.json"), ENCODING);
 
+        Mockito.when(service.generateMsg(Mockito.eq("eiffelConfidenceLevelModified"), Mockito.anyObject()))
+        .thenReturn(erlookupOptionsWithNoneFoundOutput);
+        
         Mockito.when(service.generateMsg(Mockito.eq("eiffelconfidencelevel"), Mockito.anyObject()))
                 .thenReturn(confidenceLevelOutput);
 
@@ -150,6 +165,9 @@ public class EiffelRemERLookupControllerUnitTest {
 
         Mockito.when(service.generateMsg(Mockito.eq("eiffelEnvironmentDefined"), Mockito.anyObject()))
         .thenReturn(erLookupWithOptionsOutput);
+
+        Mockito.when(service.generateMsg(Mockito.eq("eiffelEnvironmentDefinedEvent"), Mockito.anyObject()))
+        .thenReturn(erlookupOptionsWithEmptyResponseOutput);
 
         Mockito.when(service.generateMsg(Mockito.eq("eiffelCompositionDefinedEventt"), Mockito.anyObject()))
         .thenReturn(compositionDefinedOutput);
@@ -181,6 +199,20 @@ public class EiffelRemERLookupControllerUnitTest {
         Mockito.when(restTemplate.getForEntity(
                 Mockito.contains("/events?meta.type=EiffelArtifactCreatedEvent&data.identity=pkg:maven/swdi.up/CXP102051_22@R21EK?type=xml&classifier=test"),
                 Mockito.eq(String.class))).thenReturn(erLookupWithOptionsErResponse);
+        
+        ResponseEntity erLookupWithOptionsErResponse2 = new ResponseEntity(erLookupWithOptionsResponse2, HttpStatus.OK);
+        Mockito.when(restTemplate.getForEntity(
+                Mockito.contains("/events?meta.type=EiffelSourceChangeSubmittedEvent&data.gitIdentifier.commitId=ad090b60a4aedc5161da9c035a49b14a319829b4&data.gitIdentifier.repoUri=https://github.com/johndoe/myPrivateRepo.git"),
+                Mockito.eq(String.class))).thenReturn(erLookupWithOptionsErResponse2);
+        
+        ResponseEntity erLookupOptionsWithEmptyResponse = new ResponseEntity(emptyResponse, HttpStatus.OK);
+        Mockito.when(restTemplate.getForEntity(
+                Mockito.contains("/events?meta.type=EiffelSourceChangeSubmittedEvent&data.gitIdentifier.commitId=ad090b60a4aedc5161da9c035a49b14a319829e1&data.gitIdentifier.repoUri=https://github.com/myPrivateRepo.git"),
+                Mockito.eq(String.class))).thenReturn(erLookupOptionsWithEmptyResponse);
+        
+        Mockito.when(restTemplate.getForEntity(
+                Mockito.contains("/events?meta.type=EiffelArtifactCreatedEvent&data.identity=pkg:maven/swdi.up/CXP102051_22@R21EK?classifier=test"),
+                Mockito.eq(String.class))).thenReturn(erLookupOptionsWithEmptyResponse);
     }
 
     @Test
@@ -254,6 +286,16 @@ public class EiffelRemERLookupControllerUnitTest {
         ResponseEntity<?> elem = unit.generate("eiffelsemantics", "eiffelEnvironmentDefined", false, false, true, 2, json);
         assertEquals(elem.getStatusCode(), HttpStatus.OK);
     }
+    
+    @Test
+    public void testErlookupOptionsWithEmptyResponse() throws Exception {
+        File file = new File("src/test/resources/ErlookupOptionsWithEmptyResponseInput.json");
+        JsonParser parser = new JsonParser();
+        JsonObject json = parser.parse(new FileReader(file)).getAsJsonObject();
+
+        ResponseEntity<?> elem = unit.generate("eiffelsemantics", "eiffelEnvironmentDefinedEvent", true, true, true, 2, json);
+        assertEquals(elem.getStatusCode(), HttpStatus.OK);
+    }
 
     @Test
     public void testErlookupOptionsWithMultipleFound() throws Exception {
@@ -263,6 +305,16 @@ public class EiffelRemERLookupControllerUnitTest {
 
         ResponseEntity<?> elem = unit.generate("eiffelsemantics", "eiffelCompositionDefinedEventt", false, false, true, 2, json);
         assertEquals(elem.getStatusCode(), HttpStatus.EXPECTATION_FAILED);
+    }
+    
+    @Test
+    public void testErlookupOptionsWithNoneFound() throws Exception {
+        File file = new File("src/test/resources/ErlookupOptionsWithNoneFoundInput.json");
+        JsonParser parser = new JsonParser();
+        JsonObject json = parser.parse(new FileReader(file)).getAsJsonObject();
+
+        ResponseEntity<?> elem = unit.generate("eiffelsemantics", "eiffelConfidenceLevelModified", false, false, true, 2, json);
+        assertEquals(elem.getStatusCode(), HttpStatus.NOT_ACCEPTABLE);
     }
 
     @Test

--- a/service/src/test/java/com/ericsson/eiffel/remrem/generate/service/EiffelRemERLookupControllerUnitTest.java
+++ b/service/src/test/java/com/ericsson/eiffel/remrem/generate/service/EiffelRemERLookupControllerUnitTest.java
@@ -121,6 +121,15 @@ public class EiffelRemERLookupControllerUnitTest {
         String SCSubmittedResponse = FileUtils
                 .readFileToString(new File(TEST_RESOURCES_PATH+"ErlookupSCSubmittedResponse.json"), ENCODING);
 
+        String erLookupWithOptionsOutput = FileUtils
+                .readFileToString(new File(TEST_RESOURCES_PATH+"ErlookupWithOptionsOutput.json"), ENCODING);
+
+        String erLookupWithOptionsResponse = FileUtils
+                .readFileToString(new File(TEST_RESOURCES_PATH+"ErlookupWithOptionsResponse.json"), ENCODING);
+
+        String ErlookupFailedWithOptionsOutput = FileUtils
+                .readFileToString(new File(TEST_RESOURCES_PATH+"ErlookupFailedWithOptionsOutput.json"), ENCODING);
+
         Mockito.when(service.generateMsg(Mockito.eq("eiffelconfidencelevel"), Mockito.anyObject()))
                 .thenReturn(confidenceLevelOutput);
 
@@ -138,6 +147,15 @@ public class EiffelRemERLookupControllerUnitTest {
 
         Mockito.when(service.generateMsg(Mockito.eq("eiffelSCSubmitted"), Mockito.anyObject()))
                 .thenReturn(SCSubmittedOutput);
+
+        Mockito.when(service.generateMsg(Mockito.eq("eiffelEnvironmentDefined"), Mockito.anyObject()))
+        .thenReturn(erLookupWithOptionsOutput);
+
+        Mockito.when(service.generateMsg(Mockito.eq("eiffelCompositionDefinedEventt"), Mockito.anyObject()))
+        .thenReturn(compositionDefinedOutput);
+
+        Mockito.when(service.generateMsg(Mockito.eq("eiffelTestCaseStarted"), Mockito.anyObject()))
+        .thenReturn(ErlookupFailedWithOptionsOutput);
 
         ResponseEntity erresponse = new ResponseEntity(response, HttpStatus.OK);
         when(restTemplate.getForEntity(
@@ -158,6 +176,11 @@ public class EiffelRemERLookupControllerUnitTest {
         Mockito.when(restTemplate.getForEntity(
                 Mockito.contains("/events?meta.type=EiffelSourceChangeCreatedEvent&data.gitIdentifier.commitId=fd090b60a4aedc5161da9c035a49b14a319829b4&data.gitIdentifier.repoUri=https://github.com/myPrivateRepo.git"),
                 Mockito.eq(String.class))).thenReturn(SCSubmittedErResponse);
+
+        ResponseEntity erLookupWithOptionsErResponse = new ResponseEntity(erLookupWithOptionsResponse, HttpStatus.OK);
+        Mockito.when(restTemplate.getForEntity(
+                Mockito.contains("/events?meta.type=EiffelArtifactCreatedEvent&data.identity=pkg:maven/swdi.up/CXP102051_22@R21EK?type=xml&classifier=test"),
+                Mockito.eq(String.class))).thenReturn(erLookupWithOptionsErResponse);
     }
 
     @Test
@@ -220,5 +243,35 @@ public class EiffelRemERLookupControllerUnitTest {
 
         ResponseEntity<?> elem = unit.generate("eiffelsemantics", "eiffelSCSubmitted", false, true, true, 1, json);
         assertEquals(elem.getStatusCode(), HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    public void testErlookupOptions() throws Exception {
+        File file = new File("src/test/resources/ErlookupWithOptionsInput.json");
+        JsonParser parser = new JsonParser();
+        JsonObject json = parser.parse(new FileReader(file)).getAsJsonObject();
+
+        ResponseEntity<?> elem = unit.generate("eiffelsemantics", "eiffelEnvironmentDefined", false, false, true, 2, json);
+        assertEquals(elem.getStatusCode(), HttpStatus.OK);
+    }
+
+    @Test
+    public void testErlookupOptionsWithMultipleFound() throws Exception {
+        File file = new File("src/test/resources/ErlookupOptionsWithMultipleFoundInput.json");
+        JsonParser parser = new JsonParser();
+        JsonObject json = parser.parse(new FileReader(file)).getAsJsonObject();
+
+        ResponseEntity<?> elem = unit.generate("eiffelsemantics", "eiffelCompositionDefinedEventt", false, false, true, 2, json);
+        assertEquals(elem.getStatusCode(), HttpStatus.EXPECTATION_FAILED);
+    }
+
+    @Test
+    public void testErlookupFailedWithOptions() throws Exception {
+        File file = new File("src/test/resources/ErlookupFailedWithOptionsInput.json");
+        JsonParser parser = new JsonParser();
+        JsonObject json = parser.parse(new FileReader(file)).getAsJsonObject();
+
+        ResponseEntity<?> elem = unit.generate("eiffelsemantics", "eiffelTestCaseStarted", false, false, true, 2, json);
+        assertEquals(elem.getStatusCode(), HttpStatus.UNPROCESSABLE_ENTITY);
     }
 }

--- a/service/src/test/resources/EmptyResponse.json
+++ b/service/src/test/resources/EmptyResponse.json
@@ -1,0 +1,6 @@
+{
+  "pageNo": 1,
+  "pageSize": 500,
+  "totalNumberItems": 0,
+  "items": []
+}

--- a/service/src/test/resources/ErlookupFailedWithOptionsInput.json
+++ b/service/src/test/resources/ErlookupFailedWithOptionsInput.json
@@ -1,0 +1,43 @@
+{
+  "msgParams": {
+    "meta": {
+      "type": "EiffelTestCaseStartedEvent",
+      "version": "3.0.0",
+      "tags": [
+        ""
+      ],
+      "source": {
+        "domainId": "",
+        "host": "",
+        "name": "",
+        "uri": ""
+      }
+    }
+  },
+  "eventParams": {
+    "data": {
+      "executor": "",
+      "liveLogs": [],
+      "customData": []
+    },
+    "links": [
+      {
+        "type": "TEST_CASE_EXECUTION",
+        "target": "245227ed-9d6f-4485-9330-1cc92b1f947a"
+      },
+      {
+            "type": "ELEMENT",
+            "%lookup%": {
+                "eventType": "EiffelArtifactCreatedEvent",
+                "properties": [{
+                    "data.identity": "pkg:maven/swdi.up/CXP102051_22@R21EK?type=xml&classifier=test"
+                }],
+                "options": {
+                    "failIfNoneFound": "true",
+                    "falIfMultipleFound": "true"
+                }
+            }
+        }
+    ]
+  }
+}

--- a/service/src/test/resources/ErlookupFailedWithOptionsInput.json
+++ b/service/src/test/resources/ErlookupFailedWithOptionsInput.json
@@ -23,10 +23,6 @@
     "links": [
       {
         "type": "TEST_CASE_EXECUTION",
-        "target": "245227ed-9d6f-4485-9330-1cc92b1f947a"
-      },
-      {
-            "type": "ELEMENT",
             "%lookup%": {
                 "eventType": "EiffelArtifactCreatedEvent",
                 "properties": [{
@@ -34,7 +30,21 @@
                 }],
                 "options": {
                     "failIfNoneFound": "true",
-                    "falIfMultipleFound": "true"
+                    "failIfMultipleFound": "false"
+                }
+            }
+      },
+      {
+            "type": "CAUSE",
+            "%lookup%": {
+                "eventType": "EiffelSourceChangeSubmittedEvent",
+                "properties": [{
+                    "data.gitIdentifier.commitId": "ad090b60a4aedc5161da9c035a49b14a319829b4",
+                    "data.gitIdentifier.repoUri": "https://github.com/johndoe/myPrivateRepo.git"
+                }],
+                "options": {
+                    "failIfNoneFound": "true",
+                    "falIfMultipleFoud": "true"
                 }
             }
         }

--- a/service/src/test/resources/ErlookupFailedWithOptionsOutput.json
+++ b/service/src/test/resources/ErlookupFailedWithOptionsOutput.json
@@ -1,0 +1,5 @@
+{
+  "status_code": 422,
+  "result": "FAIL",
+  "message": "Link specific options could not be fulfilled"
+}

--- a/service/src/test/resources/ErlookupFailedWithOptionsOutput.json
+++ b/service/src/test/resources/ErlookupFailedWithOptionsOutput.json
@@ -1,5 +1,5 @@
 {
   "status_code": 422,
   "result": "FAIL",
-  "message": "Link specific options could not be fulfilled"
+  "message": "Link specific options could not fetch information from ER"
 }

--- a/service/src/test/resources/ErlookupFailedWithOptionsOutput.json
+++ b/service/src/test/resources/ErlookupFailedWithOptionsOutput.json
@@ -1,5 +1,5 @@
 {
   "status_code": 422,
   "result": "FAIL",
-  "message": "Link specific options could not fetch information from ER"
+  "message": "Link specific lookup options could not be fulfilled"
 }

--- a/service/src/test/resources/ErlookupOptionsWithEmptyResponseInput.json
+++ b/service/src/test/resources/ErlookupOptionsWithEmptyResponseInput.json
@@ -28,10 +28,10 @@
             "%lookup%": {
                 "eventType": "EiffelArtifactCreatedEvent",
                 "properties": [{
-                    "data.identity": "pkg:maven/swdi.up/CXP102051_22@R21EK?type=xml&classifier=test"
+                    "data.identity": "pkg:maven/swdi.up/CXP102051_22@R21EK?classifier=test"
                 }],
                 "options": {
-                    "failIfNoneFound": "true"
+                    "failIfNoneFound": "false"
                 }
             }
         },
@@ -40,9 +40,12 @@
             "%lookup%": {
                 "eventType": "EiffelSourceChangeSubmittedEvent",
                 "properties": [{
-                    "data.gitIdentifier.commitId": "ad090b60a4aedc5161da9c035a49b14a319829b4",
-                    "data.gitIdentifier.repoUri": "https://github.com/johndoe/myPrivateRepo.git"
-                }]
+                    "data.gitIdentifier.commitId": "ad090b60a4aedc5161da9c035a49b14a319829e1",
+                    "data.gitIdentifier.repoUri": "https://github.com/myPrivateRepo.git"
+                }],
+                "options": {
+                    "failIfNoneFound": "false"
+                }
             }
         }
     ]

--- a/service/src/test/resources/ErlookupOptionsWithEmptyResponseOutput.json
+++ b/service/src/test/resources/ErlookupOptionsWithEmptyResponseOutput.json
@@ -22,18 +22,5 @@
     "uri": "",
     "customData": []
   },
-  "links": [
-    {
-      "type": "PREVIOUS_VERSION",
-      "target": "de9ca618-3df0-4ed2-9c73-c6f38b725841"
-    },
-    {
-      "type": "PREVIOUS_VERSION",
-      "target": "02e01b71-6463-4c98-9aae-1e8863d58eca"
-    },
-    {
-      "type": "CAUSE",
-      "target": "d96d1c6d-e67e-4235-865a-0470ff0b005a"
-    }
-  ]
+  "links": []
 }

--- a/service/src/test/resources/ErlookupOptionsWithMultipleFoundInput.json
+++ b/service/src/test/resources/ErlookupOptionsWithMultipleFoundInput.json
@@ -1,0 +1,39 @@
+{
+    "msgParams": {
+        "meta": {
+            "type": "EiffelCompositionDefinedEvent",
+            "version": "3.0.0",
+            "tags": [
+                ""
+            ],
+            "source": {
+                "domainId": "",
+                "host": "",
+                "name": "",
+                "uri": ""
+            }
+        }
+    },
+    "eventParams": {
+        "data": {
+            "name": "required",
+            "version": "",
+            "customData": [
+
+            ]
+        },
+        "links": [{
+            "type": "ELEMENT",
+            "%lookup%": {
+                "eventType": "EiffelArtifactCreatedEvent",
+                "properties": [{
+                    "data.identity": "pkg:maven/swdi.up/CXP102051_22@R21EK?type=xml&classifier=test"
+                }],
+                "options": {
+					"failIfNoneFound": "true",
+					"failIfMultipleFound": "true"
+				}
+            }
+        }]
+    }
+}

--- a/service/src/test/resources/ErlookupOptionsWithNoneFoundInput.json
+++ b/service/src/test/resources/ErlookupOptionsWithNoneFoundInput.json
@@ -1,7 +1,7 @@
 {
     "msgParams": {
         "meta": {
-            "type": "EiffelCompositionDefinedEvent",
+            "type": "EiffelConfidenceLevelModifiedEvent",
             "version": "3.0.0",
             "tags": [
                 ""
@@ -16,37 +16,40 @@
     },
     "eventParams": {
         "data": {
-            "name": "required",
-            "version": "",
+            "name": "0",
+            "value": "SUCCESS",
+            "issuer": {
+                "name": "",
+                "email": "",
+                "id": "",
+                "group": ""
+            },
             "customData": [
 
             ]
         },
         "links": [{
-            "type": "ELEMENT",
+                "type": "SUBJECT",
             "%lookup%": {
                 "eventType": "EiffelArtifactCreatedEvent",
                 "properties": [{
                     "data.identity": "pkg:maven/swdi.up/CXP102051_22@R21EK?type=xml&classifier=test"
-                }],
-                "options": {
-                    "failIfNoneFound": "true",
-                    "failIfMultipleFound": "true"
-                }
+                }]
             }
-        },{
-            "type": "CAUSE",
+            },
+            {
+                "type": "CAUSE",
             "%lookup%": {
                 "eventType": "EiffelSourceChangeSubmittedEvent",
                 "properties": [{
-                    "data.gitIdentifier.commitId": "ad090b60a4aedc5161da9c035a49b14a319829b4",
-                    "data.gitIdentifier.repoUri": "https://github.com/johndoe/myPrivateRepo.git"
+                    "data.gitIdentifier.commitId": "ad090b60a4aedc5161da9c035a49b14a319829e1",
+                    "data.gitIdentifier.repoUri": "https://github.com/myPrivateRepo.git"
                 }],
                 "options": {
-                    "failIfNoneFound": "false",
-                    "failIfMultipleFound": "true"
+                    "failIfNoneFound": "true"
                 }
             }
-        }]
+            }
+        ]
     }
 }

--- a/service/src/test/resources/ErlookupOptionsWithNoneFoundOutput.json
+++ b/service/src/test/resources/ErlookupOptionsWithNoneFoundOutput.json
@@ -1,0 +1,5 @@
+{
+  "status_code": 406,
+  "result": "FAIL",
+  "message": "No event id found with ERLookup properties"
+}

--- a/service/src/test/resources/ErlookupWithOptionsInput.json
+++ b/service/src/test/resources/ErlookupWithOptionsInput.json
@@ -1,0 +1,40 @@
+{
+  "msgParams": {
+    "meta": {
+      "type": "EiffelEnvironmentDefinedEvent",
+      "version": "3.0.0",
+      "tags": [
+        ""
+      ],
+      "source": {
+        "domainId": "",
+        "host": "",
+        "name": "",
+        "uri": ""
+      }
+    }
+  },
+  "eventParams": {
+    "data": {
+      "name": "required",
+      "version": "",
+      "image": "",
+      "customData": [],
+      "uri": ""
+    },
+    "links": [{
+            "type": "PREVIOUS_VERSION",
+            "%lookup%": {
+                "eventType": "EiffelArtifactCreatedEvent",
+                "properties": [{
+                    "data.identity": "pkg:maven/swdi.up/CXP102051_22@R21EK?type=xml&classifier=test"
+                }],
+                "options": {
+                    "failIfNoneFound": "true",
+                    "failIfMultipleFound": "false"
+                }
+            }
+        }
+    ]
+  }
+}

--- a/service/src/test/resources/ErlookupWithOptionsOutput.json
+++ b/service/src/test/resources/ErlookupWithOptionsOutput.json
@@ -1,0 +1,35 @@
+{
+  "meta": {
+    "id": "34f7bcf9-64b6-48fa-9e6f-36498564acf1",
+    "type": "EiffelEnvironmentDefinedEvent",
+    "version": "3.0.0",
+    "time": 1590071770808,
+    "tags": [
+      ""
+    ],
+    "source": {
+      "domainId": "",
+      "host": "",
+      "name": "",
+      "serializer": "pkg:maven/com.github.eiffel-community/eiffel-remrem-semantics@2.0.13",
+      "uri": ""
+    }
+  },
+  "data": {
+    "name": "required",
+    "version": "",
+    "image": "",
+    "uri": "",
+    "customData": []
+  },
+  "links": [
+    {
+      "type": "PREVIOUS_VERSION",
+      "target": "de9ca618-3df0-4ed2-9c73-c6f38b725841"
+    },
+    {
+      "type": "PREVIOUS_VERSION",
+      "target": "02e01b71-6463-4c98-9aae-1e8863d58eca"
+    }
+  ]
+}

--- a/service/src/test/resources/ErlookupWithOptionsResponse.json
+++ b/service/src/test/resources/ErlookupWithOptionsResponse.json
@@ -1,0 +1,76 @@
+{
+    "pageNo": 1,
+    "pageSize": 2,
+    "totalNumberItems": 2,
+    "items": [{
+        "meta": {
+            "id": "de9ca618-3df0-4ed2-9c73-c6f38b725841",
+            "type": "EiffelArtifactCreatedEvent",
+            "version": "3.0.0",
+            "time": 1569489548707,
+            "tags": [],
+            "source": {
+                "domainId": "eiffel001.seki.upbuildtrigger",
+                "serializer": "pkg:maven/com.github.eiffel-community/eiffel-remrem-semantics@2.0.4"
+            }
+        },
+        "data": {
+            "identity": "pkg:maven/swdi.up/CXP102051_22@R21EK?type=xml&classifier=test",
+            "fileInformation": [],
+            "dependsOn": [],
+            "implements": [],
+            "customData": [{
+                "key": "project",
+                "value": "LTE_RBS"
+            }, {
+                "key": "lmrG1Track",
+                "value": "main"
+            }, {
+                "key": "path",
+                "value": "/proj/lterbsFtp_up/up/CXP102051%22_R21EK"
+            }, {
+                "key": "track",
+                "value": "22.10"
+            }, {
+                "key": "translatedSourceID",
+                "value": "de9ca618-3df0-4ed2-9c73-c6f38b725841"
+            }]
+        },
+        "links": []
+    }, {
+        "meta": {
+            "id": "02e01b71-6463-4c98-9aae-1e8863d58eca",
+            "type": "EiffelArtifactCreatedEvent",
+            "version": "3.0.0",
+            "time": 1569489530127,
+            "tags": [],
+            "source": {
+                "domainId": "eiffel001.seki.upbuildtrigger",
+                "serializer": "pkg:maven/com.github.eiffel-community/eiffel-remrem-semantics@2.0.4"
+            }
+        },
+        "data": {
+            "identity": "pkg:maven/swdi.up/CXP102051_22@R21EK?type=xml&classifier=test",
+            "fileInformation": [],
+            "dependsOn": [],
+            "implements": [],
+            "customData": [{
+                "key": "project",
+                "value": "LTE_RBS"
+            }, {
+                "key": "lmrG1Track",
+                "value": "main"
+            }, {
+                "key": "path",
+                "value": "/proj/lterbsFtp_up/up/CXP102051%22_R21EK"
+            }, {
+                "key": "track",
+                "value": "22.10"
+            }, {
+                "key": "translatedSourceID",
+                "value": "02e01b71-6463-4c98-9aae-1e8863d58eca"
+            }]
+        },
+        "links": []
+    }]
+}

--- a/service/src/test/resources/ErlookupWithOptionsResponse2.json
+++ b/service/src/test/resources/ErlookupWithOptionsResponse2.json
@@ -1,0 +1,48 @@
+{
+    "pageNo": 1,
+    "pageSize": 1,
+    "totalNumberItems": 1,
+    "items": [{
+  "meta": {
+    "id": "d96d1c6d-e67e-4235-865a-0470ff0b005a",
+    "type": "EiffelSourceChangeSubmittedEvent",
+    "version": "3.0.0",
+    "time": 1590382658100,
+    "tags": [
+      ""
+    ],
+    "source": {
+      "domainId": "",
+      "host": "",
+      "name": "",
+      "serializer": "pkg:maven/com.github.eiffel-community/eiffel-remrem-semantics@2.0.13",
+      "uri": ""
+    }
+  },
+  "data": {
+    "submitter": {
+      "name": "Jane Doe",
+      "email": "jane.doe@company.com",
+      "id": "j_doe",
+      "group": "Team Wombats"
+    },
+    "gitIdentifier": {
+      "commitId": "ad090b60a4aedc5161da9c035a49b14a319829b4",
+      "branch": "myBranch",
+      "repoName": "myPrivateRepo",
+      "repoUri": "https://github.com/johndoe/myPrivateRepo.git"
+    },
+    "customData": []
+  },
+  "links": [
+    {
+      "type": "CHANGE",
+      "target": "e64986ab-31d7-4252-8b88-84b08c46e4d1"
+    },
+    {
+      "type": "PREVIOUS_VERSION",
+      "target": "e64986ab-31d7-4252-8b88-84b08c46e4e4"
+    }
+  ]
+}]
+}

--- a/wiki/markdown/usage/service.md
+++ b/wiki/markdown/usage/service.md
@@ -122,9 +122,9 @@ Status codes are generated according to the below table.
 | 404         | Not Found             | Requested template is not available               | The endpoint is not found, or template for specified event type is not found                                            |
 | 406         | Not Acceptable        | No event id found with ERLookup properties        | Is returned if no event id fetched from configured event repository in REMReM generate.                                 |
 | 417         | Expectation Failed    | Multiple event ids found with ERLookup properties | Is returned if multiple event ids fetched from configured event repository in REMReM generate.                          |
+| 422         | Unprocessable Entity  | Link specific options could not fetch information from ER   | Is returned if could not fetch information from ER with specific options.                                     |
 | 500         | Internal Server Error | Internal server error                             | When REMReM Generate is down, possible to try again later when server is up                                             |
 | 503         | Service Unavailable   | "No protocol service has been found registered"   | When specified message protocol is not loaded                                                                           |
-
 
 ## Lookups
 
@@ -199,7 +199,7 @@ https://localhost:8080/eventrepository/events/?meta.type=EiffelArtifactCreatedEv
             "%lookup%": {
             "eventType": "EiffelSourceChangeCreatedEvent",
             "properties": [
-                { "data.identity": "data.gitIdentifier.repoUri": "https://gerrit.ericsson.se" }]
+                { "data.gitIdentifier.repoUri": "https://github.com/testRepo/myRepo.git" }]
                    }
                 }]
 ```
@@ -212,3 +212,87 @@ https://localhost:8080/eventrepository/events/?meta.type=EiffelArtifactCreatedEv
 | failIfNoneFound:     | False         | If value is set to True and no event id is found through (at least one of) the provided lookup definitions, then no event will be generated.|                                                                                                 
 | lookupInExternalERs:             | False          | If value is set to True then REMReM will query external ERs and not just the locally used ER. The reason for the default value to be False is to decrease the load on external ERs. Here local ER means Single ER which is using REMReM generate.  External ER means multiple ER's which are configured in Local ER.|
 | lookupLimit:            | 1             | The number of events returned, through any lookup definition given, is limited to this number. |
+
+### Lookups with Options:
+
+The options in lookups is useful to configure the parameters failIfNoneFound and failIfMultipleFound for each lookup.
+If the failIfNoneFound and failIfMultipleFound are available in lookup then it will consider this values rather than the global values.
+
+#### Examples for Lookups with Options:
+
+**Example 1 (Single Lookup with Options): **
+
+```
+          "links":[
+                  {
+            "type": "ARTIFACT",
+            "%lookup%": {
+            "eventType": "EiffelArtifactCreatedEvent",
+            "properties": [
+                { "data.identity": "pkg:maven/test/testartifact@0.0.21" }],
+                "options": {
+                    "failIfNoneFound": "true",
+                    "failIfMultipleFound": "true"
+                    }
+                  }
+                }]
+```
+
+**Example 2 (Multiple Lookups with Options):**
+
+```
+          "links":[
+                  {
+            "type": "PREVIOUS_VERSION",
+            "%lookup%": {
+            "eventType": "EiffelArtifactCreatedEvent",
+            "properties": [
+                { "data.identity": "pkg:maven/test/batik-anim@1.9.1" }],
+                "options": {
+                    "failIfNoneFound": "true",
+                    "failIfMultipleFound": "false"
+                    }
+                  }
+                },
+                {
+            "type": "CAUSE",
+            "%lookup%": {
+            "eventType": "EiffelSourceChangeSubmittedEvent",
+            "properties": [
+                { "data.gitIdentifier.commitId": "ad090b60a4aedc5161da9c035a49b14a319829b4",
+                  "data.gitIdentifier.repoUri": "https://github.com/johndoe/myPrivateRepo.git" }],
+                "options": {
+                    "failIfNoneFound": "true"
+                    }
+                  }
+                }]
+```
+
+**Example 3 :**
+
+```
+          "links":[
+                  {
+            "type": "PREVIOUS_VERSION",
+            "%lookup%": {
+            "eventType": "EiffelArtifactCreatedEvent",
+            "properties": [
+                { "data.identity": "pkg:maven/test/batik-anim@1.9.1" }],
+                "options": {
+                    "failIfMultipleFound": "true"
+                    }
+                  }
+                },
+                {
+            "type": "CAUSE",
+            "%lookup%": {
+            "eventType": "EiffelConfidenceLevelModifiedEvent",
+            "properties": [
+                { "data.value": "SUCCESS",
+                  "data.name": "readyForDelivery" }],
+                "options": {
+                    "failIfNoneFound": "true",
+                    }
+                  }
+                }]
+```

--- a/wiki/markdown/usage/service.md
+++ b/wiki/markdown/usage/service.md
@@ -122,7 +122,7 @@ Status codes are generated according to the below table.
 | 404         | Not Found             | Requested template is not available               | The endpoint is not found, or template for specified event type is not found                                            |
 | 406         | Not Acceptable        | No event id found with ERLookup properties        | Is returned if no event id fetched from configured event repository in REMReM generate.                                 |
 | 417         | Expectation Failed    | Multiple event ids found with ERLookup properties | Is returned if multiple event ids fetched from configured event repository in REMReM generate.                          |
-| 422         | Unprocessable Entity  | Link specific options could not fetch information from ER   | Is returned if could not fetch information from ER with specific options.                                     |
+| 422         | Unprocessable Entity  | Link specific lookup options could not be fulfilled   | Is returned if Link specific lookup options could not be matched with failIfMultipleFound and failIfNoneFound.      |
 | 500         | Internal Server Error | Internal server error                             | When REMReM Generate is down, possible to try again later when server is up                                             |
 | 503         | Service Unavailable   | "No protocol service has been found registered"   | When specified message protocol is not loaded                                                                           |
 
@@ -220,7 +220,7 @@ If the failIfNoneFound and failIfMultipleFound are available in lookup then it w
 
 #### Examples for Lookups with Options:
 
-**Example 1 (Single Lookup with Options): **
+**Example 1 (Single Lookup with Options):**
 
 ```
           "links":[

--- a/wiki/markdown/usage/service.md
+++ b/wiki/markdown/usage/service.md
@@ -223,76 +223,80 @@ If the failIfNoneFound and failIfMultipleFound are available in lookup then it w
 **Example 1 (Single Lookup with Options):**
 
 ```
-          "links":[
-                  {
-            "type": "ARTIFACT",
-            "%lookup%": {
+    "links": [{
+        "type": "ARTIFACT",
+        "%lookup%": {
             "eventType": "EiffelArtifactCreatedEvent",
-            "properties": [
-                { "data.identity": "pkg:maven/test/testartifact@0.0.21" }],
-                "options": {
-                    "failIfNoneFound": "true",
-                    "failIfMultipleFound": "true"
-                    }
-                  }
-                }]
+            "properties": [{
+                "data.identity": "pkg:maven/test/testartifact@0.0.21"
+            }],
+            "options": {
+                "failIfNoneFound": "true",
+                "failIfMultipleFound": "true"
+            }
+        }
+    }]
 ```
 
 **Example 2 (Multiple Lookups with Options):**
 
 ```
-          "links":[
-                  {
+    "links": [{
             "type": "PREVIOUS_VERSION",
             "%lookup%": {
-            "eventType": "EiffelArtifactCreatedEvent",
-            "properties": [
-                { "data.identity": "pkg:maven/test/batik-anim@1.9.1" }],
+                "eventType": "EiffelArtifactCreatedEvent",
+                "properties": [{
+                    "data.identity": "pkg:maven/test/batik-anim@1.9.1"
+                }],
                 "options": {
                     "failIfNoneFound": "true",
                     "failIfMultipleFound": "false"
-                    }
-                  }
-                },
-                {
+                }
+            }
+        },
+        {
             "type": "CAUSE",
             "%lookup%": {
-            "eventType": "EiffelSourceChangeSubmittedEvent",
-            "properties": [
-                { "data.gitIdentifier.commitId": "ad090b60a4aedc5161da9c035a49b14a319829b4",
-                  "data.gitIdentifier.repoUri": "https://github.com/johndoe/myPrivateRepo.git" }],
+                "eventType": "EiffelSourceChangeSubmittedEvent",
+                "properties": [{
+                    "data.gitIdentifier.commitId": "ad090b60a4aedc5161da9c035a49b14a319829b4",
+                    "data.gitIdentifier.repoUri": "https://github.com/johndoe/myPrivateRepo.git"
+                }],
                 "options": {
                     "failIfNoneFound": "true"
-                    }
-                  }
-                }]
+                }
+            }
+        }
+    ]
 ```
 
 **Example 3 :**
 
 ```
-          "links":[
-                  {
+    "links": [{
             "type": "PREVIOUS_VERSION",
             "%lookup%": {
-            "eventType": "EiffelArtifactCreatedEvent",
-            "properties": [
-                { "data.identity": "pkg:maven/test/batik-anim@1.9.1" }],
+                "eventType": "EiffelArtifactCreatedEvent",
+                "properties": [{
+                    "data.identity": "pkg:maven/test/batik-anim@1.9.1"
+                }],
                 "options": {
                     "failIfMultipleFound": "true"
-                    }
-                  }
-                },
-                {
+                }
+            }
+        },
+        {
             "type": "CAUSE",
             "%lookup%": {
-            "eventType": "EiffelConfidenceLevelModifiedEvent",
-            "properties": [
-                { "data.value": "SUCCESS",
-                  "data.name": "readyForDelivery" }],
+                "eventType": "EiffelConfidenceLevelModifiedEvent",
+                "properties": [{
+                    "data.value": "SUCCESS",
+                    "data.name": "readyForDelivery"
+                }],
                 "options": {
-                    "failIfNoneFound": "true",
-                    }
-                  }
-                }]
+                    "failIfNoneFound": "true"
+                }
+            }
+        }
+    ]
 ```


### PR DESCRIPTION
…call.

<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change
REMReM lookups controlled 'failIfNoneFound' and 'failIfMultipleFound' lookups per lookup object within an event instead of globally per call.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
