### PR TITLE
Switch to https for repo.spring.io in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <repository>
             <id>spring-milestone</id>
             <name>Spring Milestones</name>
-            <url>http://repo.spring.io/libs-milestone</url>
+            <url>https://repo.spring.io/libs-milestone</url>
         </repository>
     </repositories>
     <build>


### PR DESCRIPTION
As announced by Spring, http is no longer supported and users must
switch to https. [0]

Use of http causes build failures as shown below so this commit updates
pom.xml and switches to https for repo.spring.io.

[ERROR] Failed to execute goal on project generate-cli: Could not resolve dependencies for project com.github.eiffel-community:generate-cli:jar:2.1.2: Failed to collect dependencies at com.github.ulisesbocchio:jas
ypt-spring-boot-starter:jar:2.0.0: Failed to read artifact descriptor for com.github.ulisesbocchio:jasypt-spring-boot-starter:jar:2.0.0: Could not transfer artifact org.springframework.cloud:spring-cloud-dependenc
ies:pom:Finchley.M8 from/to spring-milestone (http://repo.spring.io/libs-milestone): Access denied to: http://repo.spring.io/libs-milestone/org/springframework/cloud/spring-cloud-dependencies/Finchley.M8/spring-cl
oud-dependencies-Finchley.M8.pom, ReasonPhrase: Forbidden. -> [Help 1]

[0] https://spring.io/blog/2019/09/16/goodbye-http-repo-spring-use-https

### Applicable Issues

Closes #176 

### Description of the Change

As announced by Spring, http is no longer supported and users must switch to https. [0]
This PR switches to https for repo.spring.io in pom.xml.

Use of http causes build failures as shown below so this commit updates pom.xml and switches to https for repo.spring.io.

[ERROR] Failed to execute goal on project generate-cli: Could not resolve dependencies for project com.github.eiffel-community:generate-cli:jar:2.1.2: Failed to collect dependencies at com.github.ulisesbocchio:jas
ypt-spring-boot-starter:jar:2.0.0: Failed to read artifact descriptor for com.github.ulisesbocchio:jasypt-spring-boot-starter:jar:2.0.0: Could not transfer artifact org.springframework.cloud:spring-cloud-dependenc
ies:pom:Finchley.M8 from/to spring-milestone (http://repo.spring.io/libs-milestone): Access denied to: http://repo.spring.io/libs-milestone/org/springframework/cloud/spring-cloud-dependencies/Finchley.M8/spring-cl
oud-dependencies-Finchley.M8.pom, ReasonPhrase: Forbidden. -> [Help 1]

[0] https://spring.io/blog/2019/09/16/goodbye-http-repo-spring-use-https

### Alternate Designs

N/A

### Benefits

Project uses https for repo.spring.io and builds can succeed.

### Possible Drawbacks

N/A

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fatih Degirmenci fatih.degirmenci@est.tech
