### PR TITLE
Updated pom structure and artifactId so GAV format is followed

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.github.eiffel-community</groupId>
-        <artifactId>eiffel-remrem-generate</artifactId>
+        <artifactId>eiffel-remrem-generate-root</artifactId>
         <version>${eiffel-remrem-generate.version}</version>
     </parent>
     <artifactId>generate-cli</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <eiffel-remrem-shared.version>2.0.5</eiffel-remrem-shared.version>
         <eiffel-remrem-semantics.version>2.1.0</eiffel-remrem-semantics.version>
     </properties>
-    <artifactId>eiffel-remrem-generate</artifactId>
+    <artifactId>eiffel-remrem-generate-root</artifactId>
     <version>${eiffel-remrem-generate.version}</version>
     <packaging>pom</packaging>
     <dependencyManagement> 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -5,10 +5,10 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.github.eiffel-community</groupId>
-        <artifactId>eiffel-remrem-generate</artifactId>
+        <artifactId>eiffel-remrem-generate-root</artifactId>
         <version>${eiffel-remrem-generate.version}</version>
     </parent>
-    <artifactId>generate-service</artifactId>
+    <artifactId>eiffel-generate-service</artifactId>
     <packaging>war</packaging>
     <dependencies>
         <dependency>


### PR DESCRIPTION



### Applicable Issues
Follow common GAV format that all Eiffel components follow.

### Description of the Change
Today eiffel-remrem-generate application is released with war artifact ArtifactID "generate-service" which do not follow GAV format where the Eiffel application name should be the used as artifactId, as other Eiffel components is following.

This change the artifactId to use the "eiffel-remrem-generate" application name instead of "generate-service" name.

This change makes also so that JitPack stores with correct  artifact name and version and path.


### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
