### PR TITLE
ER lookup retry strategy removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.1.3
 - Uplifted eiffel-remrem-parent version from 2.0.4 to 2.0.5
 - Uplifted eiffel-remrem-shared version from 2.0.4 to 2.0.5
+- Removed ER retry mechanism
 
 ## 2.1.2
 - Implemented the functionality to read the Jasypt encryption key from jasypt.key file

--- a/service/src/main/java/com/ericsson/eiffel/remrem/generate/constants/RemremGenerateServiceConstants.java
+++ b/service/src/main/java/com/ericsson/eiffel/remrem/generate/constants/RemremGenerateServiceConstants.java
@@ -18,6 +18,9 @@ public final class RemremGenerateServiceConstants {
 
         public static final String NO_SERVICE_ERROR = "{\"status_code\": 503, \"result\": \"FAIL\", "
                 + "\"message\":\"No protocol service has been found registered\"}";
+        
+        public static final String NO_ER = "{\"status_code\": 503, \"result\": \"FAIL\", "
+                + "\"message\":\"ER is down\"}";
 
         public static final String NO_TEMPLATE_ERROR = "{\"status_code\": 404, \"result\": \"FAIL\", "
                 + "\"message\":\"Requested template is not available\"}";

--- a/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/RemremGenerateController.java
+++ b/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/RemremGenerateController.java
@@ -148,6 +148,8 @@ public class RemremGenerateController {
             else {
                 return new ResponseEntity<>(parser.parse(e1.getMessage()), HttpStatus.UNPROCESSABLE_ENTITY);
             }
+        } catch (NullPointerException e) {
+            return new ResponseEntity<>(parser.parse(RemremGenerateServiceConstants.NO_SERVICE_ERROR), HttpStatus.SERVICE_UNAVAILABLE);
         } catch (Exception e) {
             log.error("Unexpected exception caught", e);
             return new ResponseEntity<>(parser.parse(RemremGenerateServiceConstants.INTERNAL_SERVER_ERROR),
@@ -174,18 +176,14 @@ public class RemremGenerateController {
                                 + String.format("&shallow=%s&pageSize=%d", !lookupInExternalERs, lookupLimit);
 
                         // Execute ER Query
-                        int j = 0;
-                        while (j < 2) {
-                            try {
-                                response = restTemplate.getForEntity(url, String.class);
-                                if (response.getStatusCode() == HttpStatus.OK) {
-                                    log.info("The result from Event Repository is: " + response.getStatusCodeValue());
-                                    break;
-                                }
-                            } catch (Exception e) {
-                                if (++j >= 2)
-                                    log.error("unable to connect configured Event Repository URL" + e.getMessage());
+                        try {
+                            response = restTemplate.getForEntity(url, String.class);
+                            if (response.getStatusCode() == HttpStatus.OK) {
+                                log.info("The result from Event Repository is: " + response.getStatusCodeValue());
+                                break;
                             }
+                        } catch (Exception e) {
+                            log.error("unable to connect configured Event Repository URL" + e.getMessage());
                         }
                         String responseBody = response.getBody();
                         ids = ERLookupController.getIdsfromResponseBody(responseBody);

--- a/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/RemremGenerateController.java
+++ b/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/RemremGenerateController.java
@@ -120,6 +120,9 @@ public class RemremGenerateController {
             bodyJson = erLookup(bodyJson, failIfMultipleFound, failIfNoneFound, lookupInExternalERs, lookupLimit);
             MsgService msgService = getMessageService(msgProtocol);
             String response;
+            if (bodyJson == null) {
+                return new ResponseEntity<>(parser.parse(RemremGenerateServiceConstants.NO_ER),HttpStatus.SERVICE_UNAVAILABLE);
+            }
             if (msgService != null) {
                 response = msgService.generateMsg(msgType, bodyJson, isLenientEnabled(okToLeaveOutInvalidOptionalFields));
                 JsonElement parsedResponse = parser.parse(response);
@@ -148,8 +151,6 @@ public class RemremGenerateController {
             else {
                 return new ResponseEntity<>(parser.parse(e1.getMessage()), HttpStatus.UNPROCESSABLE_ENTITY);
             }
-        } catch (NullPointerException e) {
-            return new ResponseEntity<>(parser.parse(RemremGenerateServiceConstants.NO_SERVICE_ERROR), HttpStatus.SERVICE_UNAVAILABLE);
         } catch (Exception e) {
             log.error("Unexpected exception caught", e);
             return new ResponseEntity<>(parser.parse(RemremGenerateServiceConstants.INTERNAL_SERVER_ERROR),
@@ -184,6 +185,7 @@ public class RemremGenerateController {
                             }
                         } catch (Exception e) {
                             log.error("unable to connect configured Event Repository URL" + e.getMessage());
+                            return null;
                         }
                         String responseBody = response.getBody();
                         ids = ERLookupController.getIdsfromResponseBody(responseBody);


### PR DESCRIPTION
### Applicable Issues
https://github.com/eiffel-community/eiffel-remrem-generate/issues/152

### Description of the Change
Removed the retry mechanism for the ER lookup and responding with a 503 status code when ER is down.

### Alternate Designs

### Benefits
Showing right status code when ER is down.

### Possible Drawbacks

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: SHUBHAM KUMAR GUPTA shubhamkumar.gupta1@tcs.com