### PR TITLE
Fix overriding semantics messaging version in newer openjdk 8 versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ Eiffel REMReM Generate takes a partial message in JSON format, validates it and 
 
 3. [**Installation**](wiki/markdown/installation.md)
 
-4. [**Run in Docker**](wiki/markdown/docker.md)
+4. [**Run Application**](wiki/markdown/run.md)
 
-5. [**Usage**](wiki/markdown/usage.md)
+5. [**Run in Docker**](wiki/markdown/docker.md)
 
-6. [**Logging**](wiki/markdown/logging.md)
+6. [**Usage**](wiki/markdown/usage.md)
+
+7. [**Logging**](wiki/markdown/logging.md)
 
 # About this repository
 The contents of this repository are licensed under the [Apache License 2.0](./LICENSE).

--- a/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/VersionService.java
+++ b/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/VersionService.java
@@ -79,7 +79,6 @@ public class VersionService {
                             String version = mainAttribs.getValue(versionKey);
                             if (version != null) {
                                 if (mainAttribs.getValue(IS_ENDPOINT_VERSION) != null) {
-                                    System.out.println("Key: " + versionKey + " Value: " + version);
                                     if(endpointVersions.get(versionKey) == null) {
                                         endpointVersions.put(versionKey, version);
                                     }

--- a/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/VersionService.java
+++ b/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/VersionService.java
@@ -20,7 +20,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
@@ -64,7 +63,6 @@ public class VersionService {
      */
     public Map<String, Map<String, String>> getMessagingVersions() {
         Enumeration<?> resEnum;
-
         try {
             resEnum = Thread.currentThread().getContextClassLoader().getResources(JarFile.MANIFEST_NAME);
             while (resEnum.hasMoreElements()) {

--- a/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/VersionService.java
+++ b/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/VersionService.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
@@ -63,7 +64,7 @@ public class VersionService {
      */
     public Map<String, Map<String, String>> getMessagingVersions() {
         Enumeration<?> resEnum;
-        
+
         try {
             resEnum = Thread.currentThread().getContextClassLoader().getResources(JarFile.MANIFEST_NAME);
             while (resEnum.hasMoreElements()) {
@@ -77,9 +78,11 @@ public class VersionService {
                         if (versionKey != null) {
                             String version = mainAttribs.getValue(versionKey);
                             if (version != null) {
-                                
                                 if (mainAttribs.getValue(IS_ENDPOINT_VERSION) != null) {
-                                    endpointVersions.put(versionKey, version);
+                                    System.out.println("Key: " + versionKey + " Value: " + version);
+                                    if(endpointVersions.get(versionKey) == null) {
+                                        endpointVersions.put(versionKey, version);
+                                    }
                                 } else {
                                     serviceVersion.put(versionKey, version);
                                 }

--- a/wiki/markdown/run.md
+++ b/wiki/markdown/run.md
@@ -13,14 +13,13 @@ RemRem-Generate application can be executed with Maven command or with the maven
 1. Change to service directory: 
 `cd service`
 
-1. Execute maven command to build and run RemRem-Generate:
+2. Execute maven command to build and run RemRem-Generate:
 `mvn spring-boot:run`
 
 
 ## Run RemRem-Generate With Java Command
 
-1. Change to service directory: 
-`cd service`
+1. Go to remrem-generate git root directory
 
 2. Execute maven package command to build the RemRem-Generate war file:
 `mvn package -DskipTests`
@@ -28,7 +27,7 @@ RemRem-Generate application can be executed with Maven command or with the maven
 This will produce a war file in the "target" folder.
 The RemRem-Generate released war file can be downloaded from JitPack.
 
-1. Run RemRem-Generate application war file
+3. Run RemRem-Generate application war file
 There is some alternatives to execute the war file with java command.
 `java -classpath service/target/generate-service-2.1.5.war org.springframework.boot.loader.WarLauncher`
 or

--- a/wiki/markdown/run.md
+++ b/wiki/markdown/run.md
@@ -56,7 +56,7 @@ Eiffel-RemRem-Generate is released with a built-in eiffel-semantic protocol vers
 Execute RemRem-Generate application with external eiffel-semantic version jar file to classpath:
 `java -classpath /path/to/protocol/eiffel-remrem-semantics-2.2.2.jar:service/target/generate-service-2.1.5.war org.springframework.boot.loader.WarLauncher`
 
-Another alternative (works only with some Java 8 versions):
+Another alternative (works only with Java 8):
 `java -Djava.ext.dirs=/home/etobiak/git3/dockerfiles/common/eiffel-remrem-generate/proto/eiffel-remrem-semantics-2.2.2.jar -jar service/target/generate-service-2.1.5.war`
 
 Go to http://localhost:8080/versions and "semanticsVersion" field should show the overridden eiffel-semantic version.

--- a/wiki/markdown/run.md
+++ b/wiki/markdown/run.md
@@ -35,7 +35,7 @@ or
 `java -jar service/target/generate-service-2.1.5.war`
 
 
-Provide customized RemRem-Generate application.properties configuration via the spring.config.location java flag that is appended to the java command line:
+Provide customized RemRem-Generate application.properties configuration via the spring.config.location java flag which need to be appended to the java command line:
 `-Dspring.config.location=/path/to/application.properties`
 
 

--- a/wiki/markdown/run.md
+++ b/wiki/markdown/run.md
@@ -56,7 +56,7 @@ Execute RemRem-Generate application with external eiffel-semantic version jar fi
 `java -classpath /path/to/protocol/eiffel-remrem-semantics-2.2.2.jar:service/target/generate-service-2.1.5.war org.springframework.boot.loader.WarLauncher`
 
 Another alternative (works only with Java 8):
-`java -Djava.ext.dirs=/home/etobiak/git3/dockerfiles/common/eiffel-remrem-generate/proto/eiffel-remrem-semantics-2.2.2.jar -jar service/target/generate-service-2.1.5.war`
+`java -Djava.ext.dirs=/path/to/protocol/eiffel-remrem-semantics-2.2.2.jar -jar service/target/generate-service-2.1.5.war`
 
 Go to http://localhost:8080/versions and "semanticsVersion" field should show the overridden eiffel-semantic version.
 

--- a/wiki/markdown/run.md
+++ b/wiki/markdown/run.md
@@ -1,0 +1,63 @@
+# Run RemRem-Generate Applciation
+
+RemRem-Generate application can be executed with Maven command or with the maven built war file.
+
+## Requirements
+
+- Java
+- Maven
+
+
+## Run RemRem-Generate With Maven Command
+
+1. Change to service directory: 
+`cd service`
+
+1. Execute maven command to build and run RemRem-Generate:
+`mvn spring-boot:run`
+
+
+## Run RemRem-Generate With Java Command
+
+1. Change to service directory: 
+`cd service`
+
+2. Execute maven package command to build the RemRem-Generate war file:
+`mvn package -DskipTests`
+
+This will produce a war file in the "target" folder.
+The RemRem-Generate released war file can be downloaded from JitPack.
+
+1. Run RemRem-Generate application war file
+There is some alternatives to execute the war file with java command.
+`java -classpath service/target/generate-service-2.1.5.war org.springframework.boot.loader.WarLauncher`
+or
+`java -jar service/target/generate-service-2.1.5.war`
+
+
+Provide customized RemRem-Generate application.properties configuration via the spring.config.location java flag that is appended to the java command line:
+`-Dspring.config.location=/path/to/application.properties`
+
+
+## Override RemRem-Generate Eiffel Protocol Version
+
+Eiffel-RemRem Protocol versions is developed and released by Github project:
+https://github.com/eiffel-community/eiffel-remrem-semantics
+
+Eiffel-RemRem-Semantic versions is released in Jitpack and can be downloaded as jar file.
+Eiffel-Remrem-Semantic releases version jar files:
+https://jitpack.io/com/github/eiffel-community/eiffel-remrem-semantics
+
+Example of one Eiffel-Semantic-version Jitpack download url address:
+https://jitpack.io/com/github/eiffel-community/eiffel-remrem-semantics/2.2.1/eiffel-remrem-semantics-2.2.1.jar
+
+Eiffel-RemRem-Generate is released with a built-in eiffel-semantic protocol version which can be overridden with a different eiffel-semantic version by adding the external eiffel-semantic version jar file to classpath.
+
+Execute RemRem-Generate application with external eiffel-semantic version jar file to classpath:
+`java -classpath /path/to/protocol/eiffel-remrem-semantics-2.2.2.jar:service/target/generate-service-2.1.5.war org.springframework.boot.loader.WarLauncher`
+
+Another alternative (works only with some Java 8 versions):
+`java -Djava.ext.dirs=/home/etobiak/git3/dockerfiles/common/eiffel-remrem-generate/proto/eiffel-remrem-semantics-2.2.2.jar -jar service/target/generate-service-2.1.5.war`
+
+Go to http://localhost:8080/versions and "semanticsVersion" field should show the overridden eiffel-semantic version.
+


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
In later java 8 version class is loaded in reversed order and if external eiffel-semantic version jar files are provided then internal built-in eiffel-semantic version is used.
External eiffel-semantic version is configured with java flag:
java -Djava.ext.dirs=/path/to/eiffel-semantic-jar-files-dir/ -jar /path/to/generate-service-x.y.z.war

-Djava.ext.dirs is deprecated in Java 8 since many years ago and the -classpath should be used in newer Java versions, example:
java -classpath "/path/to/eiffel-semantic-protocol-jars/*:publish-service/target/publish-service-2.0.26.war" org.springframework.boot.loader.WarLaunch
 

### Description of the Change
Change so external provided eiffel-semantic version is used if provided with "-Djava.ext.dirs".

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
