### PR TITLE
Generate's operation message_protocols fails for older semantics libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.11
+- Made changes to /message_protocols end-point to work for old REMRem-Semantics library.
+
 ## 2.1.10
 - Mockito framework upgraded to 5.3.1
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <eiffel-remrem-generate.version>2.1.10</eiffel-remrem-generate.version>
+        <eiffel-remrem-generate.version>2.1.11</eiffel-remrem-generate.version>
         <eiffel-remrem-semantics.version>2.2.6</eiffel-remrem-semantics.version>
     </properties>
     <artifactId>eiffel-remrem-generate</artifactId>

--- a/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/RemremGenerateController.java
+++ b/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/RemremGenerateController.java
@@ -272,6 +272,7 @@ public class RemremGenerateController {
             } catch (NoSuchMethodError | AbstractMethodError e) {
                 // Ignored intentionally in order to ensure compatibility with
                 // eiffel-remrem-semantics:2.2.0 and older.
+                log.warn("Failed due to older version of REMRem Semantics library, please use the library which is greater than 2.2.0 version.");
             }
             array.add(protocolObject);
         }

--- a/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/RemremGenerateController.java
+++ b/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/RemremGenerateController.java
@@ -267,7 +267,12 @@ public class RemremGenerateController {
         for (MsgService service : msgServices) {
             JsonObject protocolObject = new JsonObject();
             protocolObject.addProperty("name", service.getServiceName());
-            protocolObject.addProperty("edition", service.getProtocolEdition());
+            try {
+                protocolObject.addProperty("edition", service.getProtocolEdition());
+            } catch (NoSuchMethodError | AbstractMethodError e) {
+                // Ignored intentionally in order to ensure compatibility with
+                // eiffel-remrem-semantics:2.2.0 and older.
+            }
             array.add(protocolObject);
         }
         return array;

--- a/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/RemremGenerateController.java
+++ b/service/src/main/java/com/ericsson/eiffel/remrem/generate/controller/RemremGenerateController.java
@@ -272,7 +272,7 @@ public class RemremGenerateController {
             } catch (NoSuchMethodError | AbstractMethodError e) {
                 // Ignored intentionally in order to ensure compatibility with
                 // eiffel-remrem-semantics:2.2.0 and older.
-                log.warn("Failed due to older version of REMRem Semantics library, please use the library which is greater than 2.2.0 version.");
+                log.error("An old library, without implementation of MsgService.getProtocolEdition() is used. Please, upgrade to a newer library implementing eiffel-remrem-protocol-interface:2.1.2 or higher.");
             }
             array.add(protocolObject);
         }


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->Made changes to /message_protocols end-point to work for old REMRem-Semantics library. As the method getProtocolEdition() is created/implemented on semantics 2.2.0, if we use semantics library prior to that the /message_protocols end point is not working properly we are seeing 500 status error.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->Vishnu Alapati vishnu.alapati@tcs.com
